### PR TITLE
chore: add CODEOWNERS file with @bufferapp/infrastructure as default …

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @bufferapp/infrastructure


### PR DESCRIPTION
It's just adding Infra as the default owner in CODEOWNERS connect vulnerability management project and the default team assignment